### PR TITLE
changed arg type of EventmitHandler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -155,3 +155,6 @@ fabric.properties
 
 
 /lib
+
+.devcontainer
+.vscode

--- a/src/eventmit.ts
+++ b/src/eventmit.ts
@@ -1,4 +1,5 @@
-export type EventmitHandler<T> = (value: T) => any;
+type ToArgsType<T> = T extends Array<unknown> ? T : readonly [T];
+export type EventmitHandler<T> = (...args: ToArgsType<T>) => unknown;
 
 export type Eventmitter<T> = {
     /**
@@ -16,10 +17,10 @@ export type Eventmitter<T> = {
     /**
      * Invoke all handlers
      */
-    emit: (value: T) => void;
+    emit: (...value: ToArgsType<T>) => void;
 };
 
-export const eventmit: <T>() => Eventmitter<T> = <T>() => {
+export const eventmit = <T extends ReadonlyArray<unknown> | unknown = []>(): Eventmitter<T> => {
     const set = new Set<EventmitHandler<T>>();
     return {
         on(handler: EventmitHandler<T>) {
@@ -31,8 +32,8 @@ export const eventmit: <T>() => Eventmitter<T> = <T>() => {
         offAll() {
             set.clear();
         },
-        emit(value: T) {
-            set.forEach((handler) => handler(value));
+        emit(...value: ToArgsType<T>) {
+            set.forEach((handler) => handler(...value));
         },
     };
 };


### PR DESCRIPTION
It allows variable args with type.

For example
```typescript
const event1 = eventmit();
// Register handler
event1.on(() => {
    console.log(1, "value");
});
// Invoke handler
event1.emit();

const event2 = eventmit<{ key: string }>();
// Register handler
event2.on((value) => {
    console.log(1, value);
});
event2.on((value) => {
    console.log(2, value);
});
// Invoke handler
event2.emit({
    key: "value"
});
// Unregister handler
event.offAll();

const event3 = eventmit<[type:string,message:string]>();
// Register handler
event3.on((type,message) => {
    console.log(1, `eventType:${type} message:${message}`);
});
// Invoke handler
event3.emit("customEvent1","some message");